### PR TITLE
Fix "debug-stackframe" related issue

### DIFF
--- a/theme/material.product-icon-theme.json
+++ b/theme/material.product-icon-theme.json
@@ -1403,7 +1403,7 @@
       "fontCharacter": "\\EB37"
     },
     "debug-stackframe": {
-      "fontCharacter": "\\EB39"
+      "fontCharacter": "\\EB01"
     },
     "debug-stackframe-active": {
       "fontCharacter": "\\EB38"

--- a/theme/material.product-icon-theme.json
+++ b/theme/material.product-icon-theme.json
@@ -1402,6 +1402,9 @@
     "gist-secret": {
       "fontCharacter": "\\EB37"
     },
+    "debug-stackframe": {
+      "fontCharacter": "\\EB39"
+    },
     "debug-stackframe-active": {
       "fontCharacter": "\\EB38"
     },


### PR DESCRIPTION
Fix [issue #49](https://github.com/PKief/vscode-material-product-icons/issues/49).

Currently:

![image](https://user-images.githubusercontent.com/43232804/193597440-c2252de9-2679-46c6-b7f1-a0901333d562.png)

![image](https://user-images.githubusercontent.com/43232804/193597514-429c184d-8cc2-4b2e-b71d-cad9ebbacf44.png)

After fix:

![image](https://user-images.githubusercontent.com/43232804/193597813-eabce578-2161-4142-a76a-b1de796fa044.png)

![image](https://user-images.githubusercontent.com/43232804/193597910-3d83cfc5-9bf2-4bc9-9f20-7f2ccdf280cf.png)
