### PR TITLE
Make "debug-alt" more consistent

### DIFF
--- a/theme/material.product-icon-theme.json
+++ b/theme/material.product-icon-theme.json
@@ -1172,7 +1172,7 @@
       "fontCharacter": "\\EB0A"
     },
     "debug-alt": {
-      "fontCharacter": "\\EA04"
+      "fontCharacter": "\\EB2D"
     },
     "debug-disconnect": {
       "fontCharacter": "\\EB4B"


### PR DESCRIPTION
Fix [issue #50](https://github.com/PKief/vscode-material-product-icons/issues/50)

Currently:

![image](https://user-images.githubusercontent.com/43232804/193598602-f5e9416b-a3f0-4a34-9417-bdc14722342d.png)

After fix:

![image](https://user-images.githubusercontent.com/43232804/193598775-08354717-ae54-4195-838c-dfe915cfc399.png)
